### PR TITLE
chore: clean up .gitignore to exclude IntelliJ config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea/
 *.iws
 *.iml
 *.ipr


### PR DESCRIPTION
Updated the .gitignore file to fully ignore the .idea/ directory and other IntelliJ-specific files like misc.xml, vcs.xml, encoding.xml, and project_default.xml. This helps prevent unintentional commits of local IDE settings and avoids cluttering the version history with environment-specific files.

Also retained rules for other IDEs (Eclipse, NetBeans, VS Code) and OS-specific files.